### PR TITLE
fix: retract v0.1.1 due to go vet -vettool incompatibility

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,9 @@ module github.com/newmo-oss/ergo
 
 go 1.24.11
 
+// ergocheck does not work with go vet -vettool, see #8
+retract v0.1.1
+
 require (
 	github.com/google/go-cmp v0.7.0
 	github.com/gostaticanalysis/analysisutil v0.7.1


### PR DESCRIPTION
## What

Add `retract v0.1.1` directive to go.mod.

## Why

ergocheck v0.1.1 uses `singlechecker` which does not work with `go vet -vettool` flag. This PR retracts v0.1.1 to prevent users from installing a broken version.

Related: #8